### PR TITLE
New line around the prompt instead of just before it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2021-08-31
+
+- Print new line before & after the output of each prompt
+- Minor doc corrections
+
 ## [1.0.0] - 2021-07-25
 
 Initial release.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Screenshot of Gills showing the empty line after the command and the command output](./gills.png)
 
-Gills is a very simple Fish shell plugin that adds an empty line after your prompt and before the output of your command to balance the whitespace around them so you can more easily separate your prompts from your command output while skimming your terminal’s scrollback buffer.
+Gills is a very simple Fish shell plugin that adds an empty line after your prompt and the output of your command to balance the whitespace around them so you can more easily separate your prompts from your command output while skimming your terminal’s scrollback buffer.
 
 It also handles a couple of special cases like `cd`, `pushd`, and `popd` that do not produce any output. In those cases, it doesn’t add the additional empty line. If you find any other edge cases, please feel free to open an issue or a pull request.
 
@@ -18,7 +18,7 @@ fisher install small-tech/gills
 
 ## How it works
 
-Technically, like basically everything else in Fish shell, [it’s just a function](https://zerokspot.com/weblog/2016/01/16/fishy-functions/) that handles Fish shell’s `fish_postexec` event.
+Technically, like basically everything else in Fish shell, [it’s just a function](https://zerokspot.com/weblog/2016/01/16/fishy-functions/) that handles Fish shell’s `fish_preexec` & `fish_postexec` events.
 
 ## Like this? Fund us!
 

--- a/conf.d/gills.fish
+++ b/conf.d/gills.fish
@@ -1,7 +1,7 @@
 # Unless its a command known to not produce output,
-# leave an empty space before the command to better
+# leave an empty space around the command to better
 # delinate the command output from the command itself.
-function add_empty_line --on-event fish_preexec
+function add_empty_line --on-event fish_preexec --on-event fish_postexec
     if not string match -r -q 'cd.*|popd.*|pushd.*' $argv
         printf '\n'
     end


### PR DESCRIPTION
Thanks for the blog post & this small plugin. I also like having some space before & after the command. In my case, gills only placed new lines after the command so here my changes to do it around the output.

![image](https://user-images.githubusercontent.com/47731/131569733-6e7c7ce3-f1f5-4568-9fdb-cf0ab3575261.png)
